### PR TITLE
Update lua/material/util/init.lua

### DIFF
--- a/lua/material/util/init.lua
+++ b/lua/material/util/init.lua
@@ -107,8 +107,6 @@ M.load = function()
     -- schedule the async function if async is enabled
     if settings.async_loading then
         async = vim.loop.new_async(vim.schedule_wrap(load_async))
-    else
-        load_async()
     end
 
     -- apply highlights one by one
@@ -120,6 +118,8 @@ M.load = function()
 	-- if async is enabled, send the function
     if settings.async_loading then
         async:send()
+    else
+        load_async()
     end
 
     -- DONT FORGET TO REMOVE *****************************************************


### PR DESCRIPTION
Configured `custom_highlights` are applied in `load_async()`. Move the direct call to this function (executed when `settings.async_loading` is set to `false`) after the `highlights.main_highlights` have been applied to avoid the customizations being overridden by the defaults. This should fix #136.